### PR TITLE
Bump gatsby-background-image to fix issue with extension style sheets.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Marcy Sutton <marcy@gatsbyjs.com>",
   "dependencies": {
     "gatsby": "^2.0.107",
-    "gatsby-background-image": "^0.2.2",
+    "gatsby-background-image": "^0.2.3",
     "gatsby-image": "^2.0.29",
     "gatsby-plugin-feed": "^2.0.13",
     "gatsby-plugin-google-analytics": "^2.0.12",


### PR DESCRIPTION
Here is the fix for `gatsby-background-image`.

I tested the new version and it works :-)

This PR updates `package.json` to version `2.0.3` of this dependency.